### PR TITLE
label.yml für Frankfurt

### DIFF
--- a/config/locales/de.label.yml
+++ b/config/locales/de.label.yml
@@ -113,8 +113,8 @@ de:
       :meta_desc: Andalucia Ruby User Group
       :custom_recurrence: letzter Dienstag des Monats um 19:30 Uhr
     frankfurt:
-      :city: City
-      :name: Name
-      :title: Title
-      :subtitle: SubTitle
-      :meta_desc: MetaDesc
+      :city: Frankfurt am Main
+      :name: Ruby Frankfurt
+      :title: Ruby Frankfurt
+      :subtitle: Ruby Meetup Frankfurt
+      :meta_desc: Ruby / Rails Meetup Frankfurt

--- a/config/locales/de.label.yml
+++ b/config/locales/de.label.yml
@@ -116,5 +116,5 @@ de:
       :city: Frankfurt am Main
       :name: Ruby Frankfurt
       :title: Ruby Frankfurt
-      :subtitle: Ruby Meetup Frankfurt
-      :meta_desc: Ruby / Rails Meetup Frankfurt
+      :subtitle: Ruby User Group Frankfurt
+      :meta_desc: Ruby / Rails User Group Frankfurt

--- a/config/locales/en.label.yml
+++ b/config/locales/en.label.yml
@@ -113,5 +113,5 @@ en:
       :city: Frankfurt am Main
       :name: Ruby Frankfurt
       :title: Ruby Frankfurt
-      :subtitle: Ruby Meetup Frankfurt
-      :meta_desc: Ruby / Rails Meetup Frankfurt
+      :subtitle: Ruby User Group Frankfurt
+      :meta_desc: Ruby / Rails User Group Frankfurt

--- a/config/locales/en.label.yml
+++ b/config/locales/en.label.yml
@@ -110,8 +110,8 @@ en:
       :meta_desc: Andalucia Ruby User Group
       :custom_recurrence: last tuesday of each month at 7:30 p.m.
     frankfurt:
-      :city: City
-      :name: Name
-      :title: Title
-      :subtitle: SubTitle
-      :meta_desc: MetaDesc
+      :city: Frankfurt am Main
+      :name: Ruby Frankfurt
+      :title: Ruby Frankfurt
+      :subtitle: Ruby Meetup Frankfurt
+      :meta_desc: Ruby / Rails Meetup Frankfurt


### PR DESCRIPTION
Vielleicht kann ich ja ein bisschen aushelfen.

Hab einfach mal angenommen, da du das Logo anpasst (https://github.com/phoet/on_ruby/pull/528#issuecomment-507762987) dass du die Gruppe evtl. in User Group umbenennen willst.

Wenn dir `User Group` evtl. zu altbacken ist, dann ignorier den Pull Request einfach und ich mach ihn wieder zu.